### PR TITLE
Update of formula for bcd tag v0.2.2

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.1.tar.gz"
-  version "v0.2.1"
-  sha256 "d11433113280f7a4c6bd962d3644840671d0d7430101c4fc7c0caab23460447d"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.2.tar.gz"
+  version "v0.2.2"
+  sha256 "2af110501b605090ca6499b74c199c35307c9c2351a2c55147831481c7d1bf07"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.2
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow