### PR TITLE
Update of formula for bcd tag v0.2.3

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.2.tar.gz"
-  version "v0.2.2"
-  sha256 "2af110501b605090ca6499b74c199c35307c9c2351a2c55147831481c7d1bf07"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.3.tar.gz"
+  version "v0.2.3"
+  sha256 "68b8744370c565ed2d09d47a37731bc001690db2007c8aaef4ef660720deb4ef"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.3
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow