### PR TITLE
Update of formula for bcd tag v0.2.5

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.3.tar.gz"
-  version "v0.2.3"
-  sha256 "68b8744370c565ed2d09d47a37731bc001690db2007c8aaef4ef660720deb4ef"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.5.tar.gz"
+  version "v0.2.5"
+  sha256 "9a6bfeec8e35373803ee3baae8eaf2452ed7f0286333e1eab4fb05309c09876c"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.5
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow