### PR TITLE
Update of formula for bcd tag v0.2.6

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.5.tar.gz"
-  version "v0.2.5"
-  sha256 "9a6bfeec8e35373803ee3baae8eaf2452ed7f0286333e1eab4fb05309c09876c"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.6.tar.gz"
+  version "v0.2.6"
+  sha256 "c742b1a4ab2b0e27029eec553a00a937418aa74e1411c68c98c3dd81be46a32a"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.6
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow