### PR TITLE
Update of formula for bcd tag v0.2.8

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.6.tar.gz"
-  version "v0.2.6"
-  sha256 "c742b1a4ab2b0e27029eec553a00a937418aa74e1411c68c98c3dd81be46a32a"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.8.tar.gz"
+  version "v0.2.8"
+  sha256 "e4a1d0a85519b81a1fced1cf6974ef03d520d2ac25a9fad459fe70738f90ab2a"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.8
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow