### PR TITLE
Update of formula for bcd tag v0.2.10

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.9.tar.gz"
-  version "v0.2.9"
-  sha256 "124d1bad27d6f157a7a8ac3430978c4e8132bb2a61ecd690084bd6da17c3b30f"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.10.tar.gz"
+  version "v0.2.10"
+  sha256 "33c2a914b3e46df9b959bbaf8806c3ac5166f4f965498e7ead577be470440334"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.10
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow