### PR TITLE
Update of formula for bcd tag v0.2.13

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.12.tar.gz"
-  version "v0.2.12"
-  sha256 "08c16b1d86deb12ecc5629f9e0ef26ac1a544021489c76dab22b411c91a7a26d"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.13.tar.gz"
+  version "v0.2.13"
+  sha256 "e063a4215209c01d23966324ac3aec821db65c7a20195590f61ffe02229efb4b"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.2.13
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow