### PR TITLE
Update of formula for bcd tag v1.0.0

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v0.2.13.tar.gz"
-  version "v0.2.13"
-  sha256 "e063a4215209c01d23966324ac3aec821db65c7a20195590f61ffe02229efb4b"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.0.tar.gz"
+  version "v1.0.0"
+  sha256 "2ba89e1f7fc65ed63595e6a0c28ccfd562cc1f7d99191220e396267564785837"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.0
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow