### PR TITLE
Update of formula for bcd tag v1.0.2

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.1.tar.gz"
-  version "v1.0.1"
-  sha256 "dced29241a86fcb2a304b8bc396e96c47032649f17635a7c3b33fb396817bac6"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.2.tar.gz"
+  version "v1.0.2"
+  sha256 "375d4951ce72e985d49a1af065ad1fb65399629dbd1af5e7605abe0a7e3cf9cf"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.2
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow