### PR TITLE
Update of formula for bcd tag v1.0.6

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.5.tar.gz"
-  version "v1.0.5"
-  sha256 "61a822511449e96b969d750716dc0b2ff75538e052bccd0522916a6a7106eb30"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.6.tar.gz"
+  version "v1.0.6"
+  sha256 "d8909dc04aae09d8281630b7edf062d1f1ff79e7be54f24b582853423a56c86a"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.6
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow