### PR TITLE
Update of formula for bcd tag v1.0.9

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.8.tar.gz"
-  version "v1.0.8"
-  sha256 "b2aa0f2bbddc215243bf8b344fc2e2c819ea0ec4a36de64477e11d8684b8a111"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.9.tar.gz"
+  version "v1.0.9"
+  sha256 "87db06f4d2869cd07f846f0949e9c5a9d495925b13c09e162ee445bdbc871c31"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.9
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow