### PR TITLE
Update of formula for bcd tag v1.0.11

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.10.tar.gz"
-  version "v1.0.10"
-  sha256 "ca0b317330141353cf5ee14ca4896e6778689ddae25ff737766d2acbbf997cd0"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.11.tar.gz"
+  version "v1.0.11"
+  sha256 "4883f604bfa786224ef4ec0dbdb7da910615dfe2d7a4aab8dacb73b7fbd06fe6"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.11
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow