### PR TITLE
Update of formula for bcd tag v1.0.13

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.12.tar.gz"
-  version "v1.0.12"
-  sha256 "717f2d61675683da2e9b444edc9e222c60355b03a38fcb2bc4ffa7e18ccf57a2"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.13.tar.gz"
+  version "v1.0.13"
+  sha256 "02cde3829ffabaf993f7345174bc312e824430fe020ff72383ecd61c785d4507"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.13
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow