### PR TITLE
Update of formula for bcd tag v1.0.15

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.14.tar.gz"
-  version "v1.0.14"
-  sha256 "3c2d695751eb5bf3c5a0956e515ca749202851a21b8529c900ffd9dcde22970b"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.15.tar.gz"
+  version "v1.0.15"
+  sha256 "f6758c1b5ca40e32dd69117c0c9c94cd054bdc9caad40e068ed166224a20e7b0"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.15
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow