### PR TITLE
Update of formula for bcd tag v1.0.16

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.15.tar.gz"
-  version "v1.0.15"
-  sha256 "f6758c1b5ca40e32dd69117c0c9c94cd054bdc9caad40e068ed166224a20e7b0"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.16.tar.gz"
+  version "v1.0.16"
+  sha256 "0f01576e6157191f2b65fdebf04b6903b6e2859ad744bdef9063a53f1c2e6424"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.16
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow