### PR TITLE
Update of formula for bcd tag v1.0.20

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.19.tar.gz"
-  version "v1.0.19"
-  sha256 "a72513f8fa36a930a7c859dd217afac3f97c639547ba15c0f0611d2714f72600"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.20.tar.gz"
+  version "v1.0.20"
+  sha256 "56f0d81920cd960b937decf63a710dc5662dcfee463cac7be2e83ef236f2081c"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.20
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow