### PR TITLE
Update of formula for bcd tag v1.0.24

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.22.tar.gz"
-  version "v1.0.22"
-  sha256 "6228ad2407acd5e5c9598965d2dd417b74c33323b8a1b58b6a5cced27365f56a"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.24.tar.gz"
+  version "v1.0.24"
+  sha256 "6c865ad53c55de6b94e629d230eaa24fcf883f97b909bb058b6e36cd6ad074d6"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.24
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow