### PR TITLE
Update of formula for bcd tag v1.0.27

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.26.tar.gz"
-  version "v1.0.26"
-  sha256 "477b52b59d20887608a233abf4c0848bae67dd4f85e0ad9cff4b3e223e7f4ec0"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.27.tar.gz"
+  version "v1.0.27"
+  sha256 "575fb996fa8a0ca347efff6bdaaebb87073da79c796d9c73a8c44de027858b6e"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.27
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow