### PR TITLE
Update of formula for bcd tag v1.0.28

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.26.tar.gz"
-  version "v1.0.26"
-  sha256 "477b52b59d20887608a233abf4c0848bae67dd4f85e0ad9cff4b3e223e7f4ec0"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.28.tar.gz"
+  version "v1.0.28"
+  sha256 "30d03e544f34cd906b4196014d6bdeffdf1a71eb89fe42d90e8c8c972db5ff1b"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.28
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow