### PR TITLE
Update of formula for bcd tag v1.1.0

### DIFF
--- a/Formula/bcd.rb
+++ b/Formula/bcd.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class Bcd < Formula
-  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.0.29.tar.gz"
-  version "v1.0.29"
-  sha256 "038ed9b1060a0ac8961d50467b8528ea9af402430dc41a4c6158e0df47de566c"
+  url "https://github.com/a1ecbr0wn/bcd/archive/refs/tags/v1.1.0.tar.gz"
+  version "v1.1.0"
+  sha256 "a253d0ffc52cdee59a19743e67c48f61215a326a3921921ef19f9987f581fa8a"
   desc "Bookmark Change Directory - `bcd` is a way to `cd` to directories that have been bookmarked."
   homepage "http://bcd.noser.net/"
   license "Apache 2.0"
@@ -14,4 +14,3 @@ class Bcd < Formula
     system "cargo", "install", *std_cargo_args
   end
 end
-  


### PR DESCRIPTION
Update formula for v1.1.0
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow